### PR TITLE
fix: Info.plist formatting

### DIFF
--- a/example/Info.plist
+++ b/example/Info.plist
@@ -5,15 +5,17 @@
     <dict>
         <key>CFBundleURLTypes</key>
         <array>
-            <key>CFBundleURLName</key>
-            <!-- Obviously needs to be replaced with your app's bundle identifier -->
-            <string>de.fabianlars.deep-link-test</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <!-- register the myapp:// and myscheme:// schemes -->
-                <string>myapp</string>
-                <string>myscheme</string>
-            </array>
+            <dict>
+                <key>CFBundleURLName</key>
+                <!-- Obviously needs to be replaced with your app's bundle identifier -->
+                <string>de.fabianlars.deep-link-test</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <!-- register the myapp:// and myscheme:// schemes -->
+                    <string>myapp</string>
+                    <string>myscheme</string>
+                </array>
+            </dict>
         </array>
     </dict>
 </plist>


### PR DESCRIPTION
Add a required <dict> tag so that the plist is formatted correctly. Without it, the keys get converted into strings and the custom url scheme doesn't work.

Great work otherwise, the plugin seems to work flawlessly on my end. Cheers! 