### PR TITLE
Update template.desktop, Fixes #24

### DIFF
--- a/src/template.desktop
+++ b/src/template.desktop
@@ -4,4 +4,4 @@ Name={name}
 Exec={exec} %u
 Terminal=false
 MimeType={mime_types}
-NoDisplay=true
+NoDisplay=false


### PR DESCRIPTION
`NoDisplay=false` prevents OS recognizing `.desktop` file and showing Handlers.