### PR TITLE
chore: remove debug print for linux listener

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -101,7 +101,7 @@ pub fn listen<F: FnMut(String) + Send + 'static>(mut handler: F) -> Result<()> {
                         log::error!("Error reading incoming connection: {}", io_err.to_string());
                     };
 
-                    handler(dbg!(buffer));
+                    handler(buffer);
                 }
                 Err(err) => {
                     log::error!("Incoming connection failed: {}", err);


### PR DESCRIPTION
Because it's not in other listeners + there's already a 2nd debug print in the [example](https://github.com/FabianLars/tauri-plugin-deep-link/blob/e05d87aed75b2055495cb992024c4692d94adc56/example/main.rs#L20).

https://github.com/FabianLars/tauri-plugin-deep-link/blob/e05d87aed75b2055495cb992024c4692d94adc56/example/main.rs#L19-L22